### PR TITLE
Feature/0.1.6/stops admin

### DIFF
--- a/docs/2uc-admin.uml
+++ b/docs/2uc-admin.uml
@@ -9,7 +9,7 @@ usecase uc42 as "4.2 CRUD stops"
 usecase uc421 as "4.2.1 Drops stop on a map"
 usecase uc422 as "4.2.2 Selects stop on a map"
 usecase uc423 as "4.2.3 Updates stop on a map"
-usecase uc424 as "4.2.4 Deletes stop on a map"
+usecase uc424 as "4.2.4 Deletes stop"
 
 
 admin -- uc4

--- a/src/.meteor/versions
+++ b/src/.meteor/versions
@@ -50,6 +50,7 @@ less@1.0.11
 livedata@1.0.11
 localstorage@1.0.1
 logging@1.0.5
+matb33:collection-hooks@0.7.5
 meteor-platform@1.2.0
 meteor@1.1.3
 minifiers@1.1.2

--- a/src/client/home.less
+++ b/src/client/home.less
@@ -1,10 +1,11 @@
 /* CSS declarations go here */
 @media (min-width: 980px) {
 	body {
+			height: 100%;
 	    padding-top: 20px;
 	    padding-bottom: 60px;
 	}
-	
+
 	/* Custom container */
 	.container-landing {
 	    padding-top: 100px;
@@ -15,16 +16,16 @@
 	.trip-toggle {
 	    display: block;
 	    padding: 4px 15px;
-	}	
+	}
 }
 
 @media (max-width: 980px) {
 	.trip-toggle {
 	    display: block;
 	    padding: 4px 4px;
-	}	
+	}
 }
- 
+
 @media (max-width: 767px) {
   	body {
     	padding-right: 0;
@@ -37,15 +38,15 @@
     	margin-left: 0;
   	}
   	.tab-panel {
-  		padding: 0px 10px 0px 10px;	
+  		padding: 0px 10px 0px 10px;
   	}
 }
- 
+
  .form-signin {
  	background-color: #FBFBFC;
  }
- 
-  
+
+
 /* Custom container */
 .container {
 	margin: 0 auto;
@@ -66,4 +67,3 @@
 .trip-selected {
   background-color: #ECECCC;
 }
-       

--- a/src/client/views/map/Map.coffee
+++ b/src/client/views/map/Map.coffee
@@ -97,7 +97,6 @@ Template.Login.events
   "click .login": (event, template) ->
     user = template.find("#inputUsername").value
     password = template.find("#inputPassword").value
-    d "Login user " + user, ["login-error"]
     Meteor.loginWithPassword user, password, (error) ->
       if error
         d "Log in " + user + "  error: " + error.reason

--- a/src/model.js
+++ b/src/model.js
@@ -1,12 +1,11 @@
 //console.log("Loading libs");
 
-Trips = new Meteor.Collection("trips");
-Streets = new Meteor.Collection("streets");
-CityStreets = new Meteor.Collection("city_streets");
+Trips = new Mongo.Collection("trips");
+Streets = new Mongo.Collection("streets");
+CityStreets = new Mongo.Collection("city_streets");
 
-Groups = new Meteor.Collection("groups");
+Groups = new Mongo.Collection("groups");
 
-FacebookMessages = new Meteor.Collection("facebookMessages");
+FacebookMessages = new Mongo.Collection("facebookMessages");
 
-Meanings = new Meteor.Collection("meanings");
-
+Meanings = new Mongo.Collection("meanings");

--- a/src/packages/carpool-admin/client/AdminController.coffee
+++ b/src/packages/carpool-admin/client/AdminController.coffee
@@ -1,3 +1,6 @@
+###
+  Base admin controller. Checks has use admin role
+###
 class @AdminController extends RouteController
   subscriptions: ()->
     [Meteor.subscribe("adminUserContacts")]

--- a/src/packages/carpool-admin/client/AdminLanding.coffee
+++ b/src/packages/carpool-admin/client/AdminLanding.coffee
@@ -1,3 +1,6 @@
+###
+  Landing page controller to add security
+###
 class @AdminLandingController extends AdminController
   subscriptions: ()->
     [Meteor.subscribe("adminUserContacts")]

--- a/src/packages/carpool-admin/client/CarpoolAdminClient.coffee
+++ b/src/packages/carpool-admin/client/CarpoolAdminClient.coffee
@@ -1,0 +1,16 @@
+class CarpoolAdmin
+
+  createStop:(map, location) ->
+    pinImage = new (google.maps.MarkerImage)(
+      'http://maps.google.com/mapfiles/ms/icons/green-dot.png',
+      new (google.maps.Size)(32, 32),
+      new (google.maps.Point)(0, 0), new
+      (google.maps.Point)(16, 32));
+    toMarker = new (google.maps.Marker)(
+      map: map
+      position: location
+      icon: pinImage
+      draggable: true)
+    Stops.insert loc: googleServices.toLocation location
+
+@carpoolAdmin = new CarpoolAdmin

--- a/src/packages/carpool-admin/client/CarpoolAdminClient.coffee
+++ b/src/packages/carpool-admin/client/CarpoolAdminClient.coffee
@@ -1,16 +1,11 @@
+###
+  Facade object to hide service implementation details
+###
 class CarpoolAdmin
-
   createStop:(map, location) ->
-    pinImage = new (google.maps.MarkerImage)(
-      'http://maps.google.com/mapfiles/ms/icons/green-dot.png',
-      new (google.maps.Size)(32, 32),
-      new (google.maps.Point)(0, 0), new
-      (google.maps.Point)(16, 32));
-    toMarker = new (google.maps.Marker)(
-      map: map
-      position: location
-      icon: pinImage
-      draggable: true)
     Stops.insert loc: googleServices.toLocation location
+
+  deleteStop:(id) ->
+    Stops.remove {_id: id}
 
 @carpoolAdmin = new CarpoolAdmin

--- a/src/packages/carpool-admin/client/StopsAdmin.coffee
+++ b/src/packages/carpool-admin/client/StopsAdmin.coffee
@@ -1,1 +1,54 @@
-class @StopsAdmin extends AdminController
+class StopsMap
+  stopMarkers = [];
+  afterMapShown = new ParallelQueue(@);
+
+  showMap: (id, cb)->
+    mapElement = document.getElementById(id);
+    # This method is called after google services are initialized
+    googleServices.afterInit =>
+      myOptions =
+        zoom: 12
+        center: new (google.maps.LatLng)(54.67704, 25.25405)
+        mapTypeId: google.maps.MapTypeId.ROADMAP
+      @map = new (google.maps.Map)(mapElement, myOptions)
+      cb(null, @map);
+      afterMapShown.start();
+
+  showStop: afterMapShown.wrap (location)->
+    pinImage = new (google.maps.MarkerImage)(
+      'http://maps.google.com/mapfiles/ms/icons/green-dot.png',
+      new (google.maps.Size)(32, 32),
+      new (google.maps.Point)(0, 0), new
+      (google.maps.Point)(16, 32));
+    toMarker = new (google.maps.Marker)(
+      map: @map
+      position: googleServices.toLatLng (location)
+      icon: pinImage
+      draggable: true)
+
+
+  displayStops: (items)->
+    for stop in stopMarkers
+      stop.setMap(null);
+    for stop in items
+      @showStop stop.loc
+
+
+@stopsMap = new StopsMap
+
+class @StopsAdminController extends AdminController
+  subscriptions: ()->
+    d "Subscribing"
+    [Meteor.subscribe("adminUserContacts"), Meteor.subscribe("adminStops")]
+
+  data: ()->
+    d "Stops admin data"
+    stops = Stops.find().fetch();
+    stopsMap.displayStops stops
+    stops: stops;
+
+Template.StopsAdmin.rendered = ->
+  d "Stops admin rendered"
+  stopsMap.showMap "stops-admin-map", (err, map)->
+    google.maps.event.addListener map, 'click', (event)->
+      carpoolAdmin.createStop map, event.latLng

--- a/src/packages/carpool-admin/client/StopsAdmin.html
+++ b/src/packages/carpool-admin/client/StopsAdmin.html
@@ -1,3 +1,15 @@
 <template name="StopsAdmin">
-  <h2 class="stopsAdmin">Stops admin</h2>
+  <div class="row" style="height: 100%">
+    <div class="col-md-3">
+      <h2 class="stopsAdmin">Stops admin</h2>
+      <ul>
+        {{#each stops}}
+        <li>Stop</li>
+        {{/each}}
+      </ul>
+    </div>
+    <div class="col-md-9" style="height: 100%">
+      <div id="stops-admin-map" style="height: 100%"></div>
+    </div>
+  </div>
 </template>

--- a/src/packages/carpool-admin/client/StopsAdmin.html
+++ b/src/packages/carpool-admin/client/StopsAdmin.html
@@ -2,14 +2,35 @@
   <div class="row" style="height: 100%">
     <div class="col-md-3">
       <h2 class="stopsAdmin">Stops admin</h2>
-      <ul>
+      <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
         {{#each stops}}
-        <li>Stop</li>
+          {{> stopItem}}
         {{/each}}
-      </ul>
+      </div>
     </div>
     <div class="col-md-9" style="height: 100%">
       <div id="stops-admin-map" style="height: 100%"></div>
+    </div>
+  </div>
+</template>
+
+
+<template name="stopItem">
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="headingOne">
+      <h4 class="panel-title">
+        {{title}}
+        <a role="button" data-toggle="collapse" data-parent="#accordion" href="#stop-{{_id}}" aria-expanded="true" aria-controls="stop-{{_id}}">
+          <span class="glyphicon glyphicon-chevron-down pull-right" aria-hidden="true" ></span>
+        </a>
+      </h4>
+    </div>
+    <div id="stop-{{_id}}" class="panel-collapse collapse out" role="tabpanel" aria-labelledby="headingOne">
+      <div class="panel-body">
+        <button type="button" class="btn btn-default removeStop" aria-label="Left Align">
+          <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+        </button>
+      </div>
     </div>
   </div>
 </template>

--- a/src/packages/carpool-admin/package.js
+++ b/src/packages/carpool-admin/package.js
@@ -10,8 +10,15 @@ Package.onUse(function(api) {
   api.use(['underscore', 'coffeescript'], ['server', 'client']);
   api.use('templating','client');
   api.use('iron:router','client');
+  api.use("matb33:collection-hooks");
+  
+  api.use("spastai:flow-controll@0.0.2", ["client", "server"]);
+  api.use(['spastai:google-client@0.0.6'], 'client');
+
+
   api.addFiles('lib/Security.coffee');
   api.addFiles('server/publishAdmin.coffee', "server");
+  api.addFiles('client/CarpoolAdminClient.coffee', "client");
   api.addFiles('client/AdminController.coffee', "client");
   api.addFiles(['client/AdminLanding.html', 'client/AdminLanding.coffee'], "client");
   api.addFiles(['client/StopsAdmin.html', 'client/StopsAdmin.coffee'], "client");

--- a/src/packages/carpool-admin/server/publishAdmin.coffee
+++ b/src/packages/carpool-admin/server/publishAdmin.coffee
@@ -7,3 +7,6 @@ Meteor.publish 'adminUserContacts', ->
       'roles': true
       'profile': true
       "emails": true
+
+Meteor.publish 'adminStops', ->
+  Stops.find();

--- a/src/packages/carpool-admin/versions.json
+++ b/src/packages/carpool-admin/versions.json
@@ -113,6 +113,10 @@
       "1.0.5"
     ],
     [
+      "matb33:collection-hooks",
+      "0.7.5"
+    ],
+    [
       "meteor",
       "1.1.3"
     ],
@@ -163,6 +167,14 @@
     [
       "spacebars-compiler",
       "1.0.3"
+    ],
+    [
+      "spastai:flow-controll",
+      "0.0.7"
+    ],
+    [
+      "spastai:google-client",
+      "0.0.6"
     ],
     [
       "templating",

--- a/src/packages/cucumber-fixtures/hookFixtures.coffee
+++ b/src/packages/cucumber-fixtures/hookFixtures.coffee
@@ -19,6 +19,10 @@ Meteor.methods
     catch err
       console.log '---', "Creation error", err unless err.error is 403
 
+  assureStop: (title) ->
+    Stops.upsert({title: title}, {title: title, "loc" : [  25.272159576416016,  54.69387649850695 ]})
+
+
   removeTrips: (email) ->
     user = Meteor.users.findOne "emails.address": email
     console.log '---', "Remove trips for", user

--- a/src/tests/cucumber/features/step_definitions/uc41.coffee
+++ b/src/tests/cucumber/features/step_definitions/uc41.coffee
@@ -10,3 +10,6 @@ module.exports = ()->
         name: 'Admin'
     },
       roles: ['root']
+
+  @Given /^Stop "([^"]*)" is created$/, ()->
+    server.call "assureStop", "testStop-1"

--- a/src/tests/cucumber/features/uc4-admin.feature
+++ b/src/tests/cucumber/features/uc4-admin.feature
@@ -6,12 +6,10 @@ Feature: 4.1 Login as admin
   Background: Admin account exists
     Given Admin exists
 
-  @focus
   Scenario: Admin should see langing page
     Given Login with "admin@tiktai.lt"
     And I see ".stops" in "/admin"
 
-  @focus
   Scenario: Admin should see langing page
     Given Login with "user1@tiktai.lt"
     And I see ".noPermission" in "/admin"

--- a/src/tests/cucumber/features/uc41-admin-stops.feature
+++ b/src/tests/cucumber/features/uc41-admin-stops.feature
@@ -9,4 +9,7 @@ Feature: 4.1 CRUD stops
   @focus
   Scenario: 4.1.2 Selects stop on a map
     Given Login with "admin@tiktai.lt"
-    And I see ".stopsAdmin" in "/admin/stops"
+    And Stop "testStop-1" is created
+    And I see "[title='testStop-1']" in "/admin/stops"
+    When Click on "[title='testStop-1']"
+    Then I see ".removeStop"

--- a/src/tests/cucumber/features/uc41-admin-stops.feature
+++ b/src/tests/cucumber/features/uc41-admin-stops.feature
@@ -6,6 +6,7 @@ Feature: 4.1 CRUD stops
   Background: Admin account exists
     Given Admin exists
 
+  @focus
   Scenario: 4.1.2 Selects stop on a map
     Given Login with "admin@tiktai.lt"
     And I see ".stopsAdmin" in "/admin/stops"


### PR DESCRIPTION
Resolve #2 
Dar vienas pull-request'as - šį kart demonstraciniais tikslais. 
Padarytas paprastas usecase - stotelių administravimui ir panaudotas siųlomas pattern'as: 
1. Google maps valdymo logika sudėta į StopsMap
2. Biznio logika - į CarpoolAdmin
3. Testas esantis uc41-admin-stops.feature rodo kaip galima šiuo dalykus testuoti.
Sudėtingumas čia - suderinti Meteor renderinimo logika su google maps objektais.  
Testai dabar praeina, manau galima merginti.
